### PR TITLE
Improve editor usability: section headers, suffixes, tooltips, clip d…

### DIFF
--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -25,6 +25,9 @@ private:
 
     std::atomic<float>* clipEnabledParam = nullptr; // read-only on message thread for visuals
     juce::Rectangle<int> clipRowArea;
+    juce::Rectangle<int> detectorHeaderArea;
+    juce::Rectangle<int> crushHeaderArea;
+    juce::Rectangle<int> clipHeaderArea;
 
     juce::Slider threshold;
     juce::Slider attack;


### PR DESCRIPTION
…imming

- Add DETECTOR/CRUSH/CLIP section headers above each parameter row
- Add unit suffixes to all sliders (dB, ms, bits, x, %)
- Add descriptive tooltips to every control
- Dim clip Drive/Style knobs when clip is bypassed
- Add IN/CR labels to activity meters in header
- Set pointing-hand cursor on clip toggle for affordance
- Widen text boxes (72->80px) to fit suffix text
- Increase editor height (500->550) for section header space
- Flexible row height adapts to any editor size
- Simplify footer tagline for clarity

https://claude.ai/code/session_01LbA1fkwaGEDLVLxvjLEgBs